### PR TITLE
Upgrade to ragtag

### DIFF
--- a/conda_env/RagTag.yml
+++ b/conda_env/RagTag.yml
@@ -1,9 +1,10 @@
-name: RaGOO
+name: ragtag
 channels:
-  - conda-forge
   - bioconda
+  - conda-forge
 dependencies:
   - minimap2
-  - python=3
+  - ragtag
   - numpy
   - intervaltree
+  - pysam

--- a/de_novo/PGC_de_novo.snakefile
+++ b/de_novo/PGC_de_novo.snakefile
@@ -1267,5 +1267,5 @@ rule create_report_html:
         CONDA_ENV_DIR + '/jupyter.yml'
     shell:
         """
-        jupyter nbconvert {input} --output {output} --no-prompt --no-input --execute --NotebookClient.timeout=-1
+        jupyter nbconvert {input} --output {output} --no-prompt --no-input --execute --NotebookClient.timeout=-1 --ExecutePreprocessor.timeout=-1
         """

--- a/de_novo/PGC_de_novo.snakefile
+++ b/de_novo/PGC_de_novo.snakefile
@@ -228,25 +228,6 @@ rule filter_contigs:
         python {params.filter_script} {input} {params.min_length} {params.min_coverage} {output}
         """
 
-rule index_contigs_fasta:
-    """
-    Index contigs fasta. For later use by RaGOO.
-    """
-    input:
-        config["out_dir"] + "/per_sample/{sample}/assembly_{ena_ref}/contigs_filter.fasta"
-    output:
-        config["out_dir"] + "/per_sample/{sample}/assembly_{ena_ref}/contigs_filter.fasta.fai"
-    params:
-        queue=config['queue'],
-        priority=config['priority'],
-        logs_dir=LOGS_DIR
-    conda:
-        CONDA_ENV_DIR + '/samtools.yml'
-    shell:
-        """
-        samtools faidx {input}
-        """
-
 rule assembly_quast:
     """
     Run QUAST on assembly to get assembly stats and QA
@@ -281,24 +262,20 @@ rule ref_guided_assembly:
         contigs=config["out_dir"] + "/per_sample/{sample}/assembly_{ena_ref}/contigs_filter.fasta",
         ref_genome=config['reference_genome'],
     output:
-        config["out_dir"] + "/per_sample/{sample}/RG_assembly_{ena_ref}/ragoo_output/ragoo.fasta",
-        directory(config["out_dir"] + "/per_sample/{sample}/RG_assembly_{ena_ref}/ragoo_output/orderings")
+        config["out_dir"] + "/per_sample/{sample}/RG_assembly_{ena_ref}/ragtag_output/ragtag.scaffolds.fasta",
+        config["out_dir"] + "/per_sample/{sample}/RG_assembly_{ena_ref}/ragtag_output/ragtag.scaffolds.agp"
     params:
-        ragoo_script=config['ragoo_script'],
-        gap_size=config['gap_size'],
         out_dir=config["out_dir"] + "/per_sample/{sample}/RG_assembly_{ena_ref}",
         queue=config['queue'],
         priority=config['priority'],
         ppn=config['ppn'],
         logs_dir=LOGS_DIR
     conda:
-        CONDA_ENV_DIR + '/RaGOO.yml'
+        CONDA_ENV_DIR + '/RagTag.yml'
     shell:
         """
         cd {params.out_dir}
-        ln -f {input.contigs} contigs.fasta
-        ln -f {input.ref_genome} ref.fasta
-        python {params.ragoo_script} contigs.fasta ref.fasta -t {params.ppn} -g {params.gap_size}
+        ragtag.py scaffold {input.ref_genome} {input.contigs} -C -r -g 10 -t {params.ppn}
         """
 
 rule assembly_busco:
@@ -306,11 +283,11 @@ rule assembly_busco:
     Run BUSCO on assembly
     """
     input:
-        config["out_dir"] + "/per_sample/{sample}/RG_assembly_{ena_ref}/ragoo_output/ragoo.fasta"
+        config["out_dir"] + "/per_sample/{sample}/RG_assembly_{ena_ref}/ragtag_output/ragtag.scaffolds.fasta"
     output:
-        config["out_dir"] + "/per_sample/{sample}/RG_assembly_{ena_ref}/ragoo_output/run_BUSCO/short_summary_BUSCO.txt"
+       config["out_dir"] + "/per_sample/{sample}/RG_assembly_{ena_ref}/ragtag_output/BUSCO/short_summary.BUSCO.txt"
     params:
-        assembly_dir=config["out_dir"] + "/per_sample/{sample}/RG_assembly_{ena_ref}/ragoo_output",
+        assembly_dir=config["out_dir"] + "/per_sample/{sample}/RG_assembly_{ena_ref}/ragtag_output",
         busco_set=config['busco_set'],
         queue=config['queue'],
         priority=config['priority'],
@@ -321,7 +298,8 @@ rule assembly_busco:
     shell:
         """
         cd {params.assembly_dir}
-        run_busco -i {input} -o BUSCO -m genome -l {params.busco_set} -c {params.ppn} -f
+        busco -i {input} -o BUSCO -m genome -l {params.busco_set} -c {params.ppn} -f
+        cp {params.assembly_dir}/BUSCO/short_summary.specific.{params.busco_set}.BUSCO.txt {output}
         """
 
 rule prep_liftover:
@@ -330,7 +308,7 @@ rule prep_liftover:
     liftover using GAWN
     """
     input:
-        genome=config["out_dir"] + "/per_sample/{sample}/RG_assembly_{ena_ref}/ragoo_output/ragoo.fasta",
+        genome=config["out_dir"] + "/per_sample/{sample}/RG_assembly_{ena_ref}/ragtag_output/ragtag.scaffolds.fasta",
         liftover_transcripts=config["out_dir"] + "/all_samples/ref/" + config['reference_name'] + '_longest_trans.fasta'
     output:
         genome=config["out_dir"] + "/per_sample/{sample}/liftover_{ena_ref}/gawn/03_data/genome.fasta",
@@ -515,7 +493,7 @@ rule prep_chunks:
     Divide assembly into chunks for efficient parallel analysis
     """
     input:
-        fasta=config["out_dir"] + "/per_sample/{sample}/RG_assembly_{ena_ref}/ragoo_output/ragoo.fasta",
+        fasta=config["out_dir"] + "/per_sample/{sample}/RG_assembly_{ena_ref}/ragtag_output/ragtag.scaffolds.fasta"
     output:
         config["out_dir"] + "/per_sample/{sample}/chunks_{ena_ref}/chunks.lft"
     params:
@@ -796,19 +774,16 @@ rule make_contigs_bed:
     Useful as part of annotation evidence collection.
     """
     input:
-        ord_dir=directory(config["out_dir"] + "/per_sample/{sample}/RG_assembly_{ena_ref}/ragoo_output/orderings"),
-        faidx=config["out_dir"] + "/per_sample/{sample}/assembly_{ena_ref}/contigs_filter.fasta.fai"
+        config["out_dir"] + "/per_sample/{sample}/RG_assembly_{ena_ref}/ragtag_output/ragtag.scaffolds.agp"
     output:
         config["out_dir"] + "/per_sample/{sample}/annotation_{ena_ref}/evidence/contigs.bed"
     params:
-        ragoo_contigs_script=os.path.join(pipeline_dir,"ragoo_ordering_to_bed.py"),
-        gap_size=config['gap_size'],
         queue=config['queue'],
         priority=config['priority'],
         logs_dir=LOGS_DIR
     shell:
         """
-        python {params.ragoo_contigs_script} {input.ord_dir} {input.faidx} {params.gap_size} {output}
+        awk '$5 == "W" {{print $1"\t"$2"\t"$3"\t"$6}}' {input} > {output}
         """
 
 rule index_evidence_gff:
@@ -826,7 +801,7 @@ rule index_evidence_gff:
         config["out_dir"] + "/per_sample/{sample}/annotation_{ena_ref}/evidence/maker.all.chr.protein2genome.gff",
         config["out_dir"] + "/per_sample/{sample}/annotation_{ena_ref}/evidence/chunks.bed",
         config["out_dir"] + "/per_sample/{sample}/assembly_{ena_ref}/QUAST/report.html",
-        config["out_dir"] + "/per_sample/{sample}/RG_assembly_{ena_ref}/ragoo_output/run_BUSCO/short_summary_BUSCO.txt"
+        config["out_dir"] + "/per_sample/{sample}/RG_assembly_{ena_ref}/ragtag_output/BUSCO/short_summary.BUSCO.txt"
     output:
         config["out_dir"] + "/per_sample/{sample}/annotation_{ena_ref}/evidence/done"
     params:
@@ -941,7 +916,6 @@ rule prep_for_orthofinder:
     matching genome names.
     """
     input:
-        #ev=config["out_dir"] + "/per_sample/{sample}/annotation_{ena_ref}/evidence/done",
         fasta=config["out_dir"] + "/per_sample/{sample}/annotation_{ena_ref}/maker.proteins_filter_nodupl.fasta"
     output:
         config["out_dir"] + "/all_samples/orthofinder/{sample}_{ena_ref}_LQ.fasta"
@@ -1219,8 +1193,8 @@ rule prep_for_collect_stats:
     """
     input:
         quast=expand(config["out_dir"] + "/per_sample/{sample}/assembly_{ena_ref}/QUAST/report.tsv", zip, sample=config['samples_info'].keys(),ena_ref=[x['ena_ref'] for x in config['samples_info'].values()]),
-        busco=expand(config["out_dir"] + "/per_sample/{sample}/RG_assembly_{ena_ref}/ragoo_output/run_BUSCO/short_summary_BUSCO.txt", zip, sample=config['samples_info'].keys(),ena_ref=[x['ena_ref'] for x in config['samples_info'].values()]),
-        ragoo=expand(config["out_dir"] + "/per_sample/{sample}/RG_assembly_{ena_ref}/ragoo_output/ragoo.fasta", zip, sample=config['samples_info'].keys(),ena_ref=[x['ena_ref'] for x in config['samples_info'].values()])
+        busco=expand(config["out_dir"] + "/per_sample/{sample}/RG_assembly_{ena_ref}/ragtag_output/BUSCO/short_summary.BUSCO.txt", zip, sample=config['samples_info'].keys(),ena_ref=[x['ena_ref'] for x in config['samples_info'].values()]),
+        ragtag=expand(config["out_dir"] + "/per_sample/{sample}/RG_assembly_{ena_ref}/ragtag_output/ragtag.scaffolds.fasta", zip, sample=config['samples_info'].keys(),ena_ref=[x['ena_ref'] for x in config['samples_info'].values()])
     output:
         config["out_dir"] + "/all_samples/stats/assembly_stats_files.tsv"
     params:
@@ -1230,12 +1204,12 @@ rule prep_for_collect_stats:
         logs_dir=LOGS_DIR,
     shell:
         """
-        paste <(echo {params.samples} | tr ' ' '\n') <(echo {input.quast} | tr ' ' '\n') <(echo {input.busco} | tr ' ' '\n') <(echo {input.ragoo} | tr ' ' '\n') > {output}
+        paste <(echo {params.samples} | tr ' ' '\n') <(echo {input.quast} | tr ' ' '\n') <(echo {input.busco} | tr ' ' '\n') <(echo {input.ragtag} | tr ' ' '\n') > {output}
         """
 
 rule collect_assembly_stats:
     """
-    Collect QUAST, BUSCO and RaGOO
+    Collect QUAST, BUSCO and RagTag
     stats for LQ samples
     """
     input:

--- a/de_novo/conf_template_de_novo.yml
+++ b/de_novo/conf_template_de_novo.yml
@@ -18,9 +18,6 @@ merge_max_mismatch_ratio: 0.2
 # Assembly
 min_length: 500
 min_coverage: 2
-ragoo_script:
-gap_size: 10
-contig_borders_script:
 busco_set:
 
 # GAWN liftover

--- a/map_to_pan/PGC_map_to_pan.snakefile
+++ b/map_to_pan/PGC_map_to_pan.snakefile
@@ -246,7 +246,7 @@ rule assembly_busco:
     input:
         config["out_dir"] + "/per_sample/{sample}/assembly_{ena_ref}/contigs_filter.fasta"
     output:
-        config["out_dir"] + "/per_sample/{sample}/assembly_{ena_ref}/run_BUSCO/short_summary_BUSCO.txt"
+        config["out_dir"] + "/per_sample/{sample}/assembly_{ena_ref}/BUSCO/short_summary.BUSCO.txt"
     params:
         assembly_dir=config["out_dir"] + "/per_sample/{sample}/assembly_{ena_ref}",
         busco_set=config['busco_set'],
@@ -260,6 +260,7 @@ rule assembly_busco:
         """
         cd {params.assembly_dir}
         busco -i {input} -o BUSCO -m genome -l {params.busco_set} -c {params.ppn} -f
+        cp {params.assembly_dir}/BUSCO/short_summary.specific.{params.busco_set}.BUSCO.txt {output}
         """
 
 rule assembly_quast:
@@ -1054,7 +1055,6 @@ rule calculate_stepwise_stats:
         """
         python {params.stepwise_script} {input} 100 {output}
         """
-
 rule prep_for_collect_stats:
     """
     Prepare the TSV required for
@@ -1062,7 +1062,7 @@ rule prep_for_collect_stats:
     """
     input:
         quast=expand(config["out_dir"] + "/per_sample/{sample}/assembly_{ena_ref}/QUAST/report.tsv", zip, sample=config['samples_info'].keys(),ena_ref=[x['ena_ref'] for x in config['samples_info'].values()]),
-        busco=expand(config["out_dir"] + "/per_sample/{sample}/assembly_{ena_ref}/run_BUSCO/short_summary_BUSCO.txt", zip, sample=config['samples_info'].keys(),ena_ref=[x['ena_ref'] for x in config['samples_info'].values()])
+        busco=expand(config["out_dir"] + "/per_sample/{sample}/assembly_{ena_ref}/BUSCO/short_summary.BUSCO.txt", zip, sample=config['samples_info'].keys(),ena_ref=[x['ena_ref'] for x in config['samples_info'].values()])
     output:
         config["out_dir"] + "/all_samples/stats/assembly_stats_files.tsv"
     params:

--- a/map_to_pan/PGC_map_to_pan.snakefile
+++ b/map_to_pan/PGC_map_to_pan.snakefile
@@ -1135,5 +1135,5 @@ rule create_report_html:
         CONDA_ENV_DIR + '/jupyter.yml'
     shell:
         """
-        jupyter nbconvert {input} --output {output} --no-prompt --no-input --execute --NotebookClient.timeout=-1
+        jupyter nbconvert {input} --output {output} --no-prompt --no-input --execute --NotebookClient.timeout=-1 --ExecutePreprocessor.timeout=-1
         """

--- a/pan_genome_report/collect_stats.py
+++ b/pan_genome_report/collect_stats.py
@@ -35,7 +35,7 @@ with open(in_tsv) as f:
       total_len = 0
       chr0_len = None
       for rec in SeqIO.parse(ragoo_fasta,'fasta'):
-        if rec.id == "Chr0_RaGOO":
+        if rec.id == "Chr0_RagTag":
           chr0_len = len(rec.seq)
           total_len += len(rec.seq)
         else:

--- a/test/data/fix_ids.py
+++ b/test/data/fix_ids.py
@@ -1,0 +1,21 @@
+in_gff = "GCA_000149365.1_ASM14936v1_genomic.gff"
+in_prot = "GCA_000149365.1_ASM14936v1_protein.faa"
+
+replace = {}
+with open(in_gff) as f:
+  for line in f:
+    if line.startswith('#'):
+      continue
+    fields = line.strip().split('\t')
+    if fields[2] == "CDS":
+      attr = {k.split('=')[0]: k.split('=')[1] for k in line.split('\t')[8].split(';')}
+      replace[attr["Name"]] = attr["Parent"]
+with open(in_prot) as f:
+  for line in f:
+    line = line.strip()
+    if line.startswith('>'):
+      name = line.split()[0][1:]
+      print(">%s" % replace[name])
+    else:
+      print(line)
+

--- a/test/data/get_test_data.sh
+++ b/test/data/get_test_data.sh
@@ -18,7 +18,8 @@ wget https://ftp.ncbi.nlm.nih.gov/genomes/genbank/fungi/Saccharomyces_cerevisiae
 wget https://ftp.ncbi.nlm.nih.gov/genomes/genbank/fungi/Saccharomyces_cerevisiae/latest_assembly_versions/GCA_000149365.1_ASM14936v1/GCA_000149365.1_ASM14936v1_rna_from_genomic.fna.gz
 gzip -d *.gz
 sed -i 's/>.*locus_tag=\([^]]*\)].*/>rna-\1/' GCA_000149365.1_ASM14936v1_rna_from_genomic.fna
-sed -i 's/>.*locus_tag=\([^]]*\)].*/>rna-\1/' GCA_000149365.1_ASM14936v1_protein.faa
+python fix_ids.py > GCA_000149365.1_ASM14936v1_protein.faa.fix
+mv GCA_000149365.1_ASM14936v1_protein.faa.fix GCA_000149365.1_ASM14936v1_protein.faa
 
 # T73
 wget http://sgd-archive.yeastgenome.org/sequence/strains/T73/T73_WashU_2011_AFDF01000000/T73_WashU_2011_AFDF01000000.fsa.gz


### PR DESCRIPTION
In de-novo pipeline, upgrade from RaGOO to RagTag for reference-guided assembly.
The PR also contains a few unrelated fixes that were caught while making the main change.